### PR TITLE
Sign and add refactor

### DIFF
--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -392,7 +392,7 @@ class Operations(Cog):
     async def add_signup(op: dict, sign_up_name, main_role, alt_role: None) -> dict:
         """
         Adds a user with given name and roles to the given operation
-        :param op: The operation to be updated
+        :param op: The operation to be updated.
         :param sign_up_name: The user's nick name.
         :param main_role: The main role of the user.
         :param alt_role: Optional alternative role of the user.
@@ -425,6 +425,12 @@ class Operations(Cog):
 
     @staticmethod
     async def remove_signup(op: dict, user_nick) -> dict:
+        """
+        Attempts to removes the user with given name from the operation.
+        :param op: The operation to be updated.
+        :param user_nick: The user's nick name.
+        :return: dict: The updated operation. 
+        """
         for role in ["Tank", "Healer", "Dps"]:
             for i, user in enumerate(op["Sign-ups"][role]):
                 if user_nick in user:

--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -613,6 +613,14 @@ class Operations(Cog):
         return choice(list(self.operations.keys()))
 
     async def add_to_operation(self, ctx: context, op: dict, op_number: str, sign_up_name: str, main_role: str, alt_role = None) -> None:
+        """
+        Adds the given user to the sign ups. (validates parameters)
+        :param op: The operation to add the person to.
+        :param op_number: The id of the operation.
+        :param sign_up_name: The name of the person to be added.
+        :param main_role: The main role of the person to be added.
+        :param alt_role: The alt role of the person to be added.
+        """
         if not op:
             message = await ctx.send("There is no Operation with that number.")
             await message.delete(delay=10)


### PR DESCRIPTION
Refactor done as part of #5 

Summary of changes:
- created __add_signup()__ to add a user to their role in an operation (no validation on role being full -> check before calling)
- refactored __-sign__ and __-add__ commands to use __add_to_operation()__ for their common logic (validation, add_signup, write to json, update pinned post)
- added missing method description comment to __remove_signup()__

Potential improvements for the future:
- finish #5 
- Deal with the 'error cases' in __add_to_operation()__ in a different way (sending error messages ...) -> try not to pass context into __add_to_operation()__ so it becomes independent of __discord.py__ -> could be useful in the future.