### PR TITLE
Feature/reaction signups

### DIFF
--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -661,7 +661,6 @@ class Operations(Cog):
             await ctx.send("You must add a alternative role to sign as reserve.")
             return
 
-
         if await self.check_duplicate(op, sign_up_name):
             if not await self.check_role_change(op, sign_up_name, main_role, alt_role):
                 await ctx.send("You have already signed-up for that operation.")

--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -8,7 +8,7 @@ from random import choice
 
 
 class Operations(Cog):
-    def __init__(self, bot):
+    def __init__(self, bot, ops):
         self.bot = bot
         self.operations = {"s&v": "Scum and Villainy", "tfb": "Terror From Beyond", "kp": "Karagga's Palace",
                            "ev": "Eternity Vault", "ec": "Explosive Conflict", "df": "Dread Fortress",
@@ -20,8 +20,7 @@ class Operations(Cog):
                       16: {"Tank": 2, "Dps": 10, "Healer": 4}}
         self.difficulties = {"sm": "Story Mode", "hm": "Veteran Mode", "nim": "Master Mode", "vm": "Veteran mode",
                              "mm": "Master Mode"}
-        with open('./Ops.json', 'r') as f:
-            self.ops = load(f)
+        self.ops = ops
 
     @command(aliases=["ops", "operations", "list"])
     async def list_all_operations(self, ctx: context) -> None:

--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -715,7 +715,9 @@ class Operations(Cog):
         if not role:
             return
         try:
-            op = await self.add_to_operation(op, id, payload.guild_id, payload.member.nick, role, None)
+            guild = self.bot.get_guild(payload.guild_id)
+            user = guild.get_member(payload.user_id)
+            await self.add_to_operation(op, id, payload.guild_id, user.display_name, role, None)
         except SignUpError:
             pass
 

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -3,10 +3,14 @@ from discord import Game
 from discord.ext import commands
 from Cogs.Operations import Operations
 from Cogs.Swtor import Swtor
+from json import load
 
 bot_prefix = "-"
 with open('./token.txt', 'r') as f:
     token = f.read()
+
+with open('./Ops.json', 'r') as f:
+    ops = load(f)
 
 client = Bot(command_prefix=bot_prefix)
 
@@ -44,6 +48,6 @@ async def github(ctx):
 # async def on_reaction_add(reaction, user):
 #     print(reaction.message)
 
-client.add_cog(Operations(client))
+client.add_cog(Operations(client, ops))
 client.add_cog(Swtor(client))
 client.run(token)

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 from Cogs.Operations import Operations
 from Cogs.Swtor import Swtor
 from json import load
+from Utils.ReactionUtils import find_operation_by_id
 
 bot_prefix = "-"
 with open('./token.txt', 'r') as f:
@@ -44,9 +45,12 @@ async def github(ctx):
     await ctx.send("The bot is written in Python using the discord.py framework. The code is available here: "
                    "https://github.com/Maskonk/SWTOR_Op_Bot")
 
-# @client.event
-# async def on_reaction_add(reaction, user):
-#     print(reaction.message)
+@client.event
+async def on_reaction_add(reaction, user):
+    if reaction.me:
+        return
+    a = await find_operation_by_id(ops, reaction.message.guild.id, reaction.message.id)
+    print(a)
 
 client.add_cog(Operations(client, ops))
 client.add_cog(Swtor(client))

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -1,5 +1,5 @@
 from discord.ext.commands import Bot
-from discord import Game
+from discord import Game, Intents
 from discord.ext import commands
 from Cogs.Operations import Operations
 from Cogs.Swtor import Swtor
@@ -13,7 +13,9 @@ with open('./token.txt', 'r') as f:
 with open('./Ops.json', 'r') as f:
     ops = load(f)
 
-client = Bot(command_prefix=bot_prefix)
+intents = Intents.default()
+intents.members = True
+client = Bot(command_prefix=bot_prefix, intents=intents)
 
 
 @client.event

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 from Cogs.Operations import Operations
 from Cogs.Swtor import Swtor
 from json import load
-from Utils.ReactionUtils import find_operation_by_id, check_valid_reaction
+from Utils.ReactionUtils import *
 
 bot_prefix = "-"
 with open('./token.txt', 'r') as f:
@@ -24,7 +24,9 @@ async def on_ready():
 
 @client.event
 async def on_command_error(ctx, error):
-    if isinstance(error, commands.CommandNotFound):
+    if hasattr(ctx.command, 'on_error'):
+        return
+    elif isinstance(error, commands.CommandNotFound):
         await ctx.send("That is not a valid command. Please use **.help** for a list of all commands.")
     elif isinstance(error, commands.CheckFailure):
         await ctx.send("You are not authorized to use this command.")
@@ -44,18 +46,6 @@ async def github(ctx):
     """Link to the github repo for this bot."""
     await ctx.send("The bot is written in Python using the discord.py framework. The code is available here: "
                    "https://github.com/Maskonk/SWTOR_Op_Bot")
-
-
-@client.event
-async def on_raw_reaction_add(payload):
-    """
-    Runs when a reaction is added to a message. Used for reaction based sign ups.
-    """
-    op = await find_operation_by_id(ops, payload.guild_id, payload.message_id)
-    if not op:
-        return
-    role = await check_valid_reaction(payload.emoji.name)
-    print(role)
 
 client.add_cog(Operations(client, ops))
 client.add_cog(Swtor(client))

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 from Cogs.Operations import Operations
 from Cogs.Swtor import Swtor
 from json import load
-from Utils.ReactionUtils import find_operation_by_id
+from Utils.ReactionUtils import find_operation_by_id, check_valid_reaction
 
 bot_prefix = "-"
 with open('./token.txt', 'r') as f:
@@ -45,12 +45,17 @@ async def github(ctx):
     await ctx.send("The bot is written in Python using the discord.py framework. The code is available here: "
                    "https://github.com/Maskonk/SWTOR_Op_Bot")
 
+
 @client.event
-async def on_reaction_add(reaction, user):
-    if reaction.me:
+async def on_raw_reaction_add(payload):
+    """
+    Runs when a reaction is added to a message. Used for reaction based sign ups.
+    """
+    op = await find_operation_by_id(ops, payload.guild_id, payload.message_id)
+    if not op:
         return
-    a = await find_operation_by_id(ops, reaction.message.guild.id, reaction.message.id)
-    print(a)
+    role = await check_valid_reaction(payload.emoji.name)
+    print(role)
 
 client.add_cog(Operations(client, ops))
 client.add_cog(Swtor(client))

--- a/src/Utils/Errors.py
+++ b/src/Utils/Errors.py
@@ -1,0 +1,6 @@
+class Error(Exception):
+    pass
+
+
+class SignUpError(Error):
+    pass

--- a/src/Utils/ReactionUtils.py
+++ b/src/Utils/ReactionUtils.py
@@ -1,17 +1,18 @@
-from json import load
+from Cogs.Operations import Operations
 
-# with open('../Ops.json', 'r') as f:
-#     ops = load(f)
-
-
-async def find_operation_by_id(ops, guild_id: str, op_id: str):
+async def find_operation_by_id(ops: dict, guild_id: str, op_id: str) -> dict:
     guild = ops.get(str(guild_id), {})
     for op in guild.values():
         if op["Post_id"] == int(op_id):
             return op
 
+async def check_valid_reaction(reaction: str) -> str:
+    standard = {"🇹": "Tank", "🇩": "Dps", "🇭": "Healer"}
+    if reaction in standard.keys():
+        role = standard[reaction]
+    elif reaction in ["Tank", "Healer", "DPS"]:
+        role = reaction
+    else:
+        role = None
+    return role.capitalize()
 
-
-
-# a = find_operation_by_id("323229951098748928", "774060104374943786")
-# print(a)

--- a/src/Utils/ReactionUtils.py
+++ b/src/Utils/ReactionUtils.py
@@ -1,18 +1,9 @@
-from Cogs.Operations import Operations
-
-async def find_operation_by_id(ops: dict, guild_id: str, op_id: str) -> dict:
-    guild = ops.get(str(guild_id), {})
-    for op in guild.values():
-        if op["Post_id"] == int(op_id):
-            return op
-
 async def check_valid_reaction(reaction: str) -> str:
     standard = {"🇹": "Tank", "🇩": "Dps", "🇭": "Healer"}
     if reaction in standard.keys():
         role = standard[reaction]
     elif reaction in ["Tank", "Healer", "DPS"]:
-        role = reaction
+        role = reaction.capitalize()
     else:
         role = None
-    return role.capitalize()
-
+    return role

--- a/src/Utils/ReactionUtils.py
+++ b/src/Utils/ReactionUtils.py
@@ -1,0 +1,17 @@
+from json import load
+
+# with open('../Ops.json', 'r') as f:
+#     ops = load(f)
+
+
+async def find_operation_by_id(ops, guild_id: str, op_id: str):
+    guild = ops.get(str(guild_id), {})
+    for op in guild.values():
+        if op["Post_id"] == int(op_id):
+            return op
+
+
+
+
+# a = find_operation_by_id("323229951098748928", "774060104374943786")
+# print(a)


### PR DESCRIPTION
Add the ability to sign up with certain reactions on the operation messages. Currently can only sign up with one role, signing up with a second will change the main role, an alternative role can not be added with reactions at the moment.