### PR TITLE
Feature/admin cog

### DIFF
--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -1,4 +1,4 @@
-from discord.ext.commands import Cog, command, context
+from discord.ext.commands import Cog, command, context, check
 from discord.utils import get
 from datetime import datetime
 from json import dump
@@ -14,17 +14,18 @@ class Admin(Cog):
 
     async def is_server_admin(self, ctx: context) -> bool:
         admins = self.config.get(str(ctx.guild.id), {}).get("Admins", [])
-        return ctx.author.id in admins
+        return ctx.author.id in admins or ctx.author.id in [168009927015661568]
 
     @command(hidden=True)
-    @commands.check(is_server_admin)
+    # @check(is_server_admin)
     async def delete_all(self, ctx: context) -> None:
         """
         Deletes all operations for the given server.
         """
         if not await self.is_server_admin(ctx):
+            await ctx.send("You are not authorized to use this command.")
             return
-        self.ops[str(ctx.guild.id)] = []
+        self.ops[str(ctx.guild.id)] = {}
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)
 

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -1,8 +1,22 @@
 from discord.ext.commands import Cog, command, context
+from json import dump
+
 
 class Admin(Cog):
     def __init__(self, bot, ops):
         self.bot = bot
         self.ops = ops
+
+    @command()
+    async def delete_all(self, ctx: context) -> None:
+        """
+        Deletes all operations for the given server.
+        """
+        print("Here")
+        print(self.ops)
+        self.ops[str(ctx.guild.id)] = []
+        print(self.ops)
+        with open('./Ops.json', 'w') as f:
+            dump(self.ops, f)
 
 

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -1,0 +1,8 @@
+from discord.ext.commands import Cog, command, context
+
+class Admin(Cog):
+    def __init__(self, bot, ops):
+        self.bot = bot
+        self.ops = ops
+
+

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -14,7 +14,7 @@ class Admin(Cog):
 
     async def is_server_admin(self, ctx: context) -> bool:
         admins = self.config.get(str(ctx.guild.id), {}).get("Admins", [])
-        return ctx.author.id in admins or ctx.author.id in [168009927015661568]
+        return ctx.author.id in admins or ctx.author.id in [168009927015661568, 165463629171261440]
 
     @command(hidden=True, aliases=["da", "deleteall"])
     async def delete_all(self, ctx: context) -> None:

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -1,5 +1,9 @@
 from discord.ext.commands import Cog, command, context
+from discord.utils import get
+from datetime import datetime
 from json import dump
+from .Operations import Operations
+from calendar import month_name, day_name
 
 
 class Admin(Cog):
@@ -16,4 +20,73 @@ class Admin(Cog):
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)
 
+    @command(hidden=True)
+    async def reset_ids(self, ctx: context) -> None:
+        ops = self.ops.get(str(ctx.guild.id), ())
+        i = 1
+        temp = {}
+        print(ops.keys())
+        for op in ops.values():
+            await self.edit_pinned_message(op, i, ctx.guild.id)
+            temp[i] = op
+            i += 1
+        self.ops[str(ctx.guild.id)] = temp
+        with open('./Ops.json', 'w') as f:
+            dump(self.ops, f)
+
+    async def make_operation_message(self, dt: datetime, op: dict, op_id: str) -> str:
+        """
+        Composes operation message.
+        :param dt: The Datetime object of the operation
+        :param op: The operation details dictionary.
+        :param op_id: The id of the operation.
+        :return: String of the message to send composed of the operations details.
+        """
+        guild = self.bot.get_guild(750036082518917170)
+        dps_emoji = get(guild.emojis, name='DPS')
+        heal_emoji = get(guild.emojis, name='Healer')
+        tank_emoji = get(guild.emojis, name='Tank')
+        operation_name = Operations.operations[op['Operation'].lower()]
+        difficulty = Operations.difficulties[op['Difficulty'].lower()]
+        notes = op["Notes"]
+        size = sum(Operations.sizes[str(op['Size'])].values())
+        extension = await Operations.date_extension(dt.day)
+        msg = f"{op_id}: {size}m {operation_name} {difficulty} {op['Side']}\n{day_name[dt.weekday()]} the " \
+              f"{extension} of {month_name[dt.month]} " \
+              f"starting at {dt.time().strftime('%H:%M')} CET."
+        if notes:
+            msg += f"\n({notes})\n"
+        msg += f"Current signups:\n"
+        for tank in op['Sign-ups']['Tank']:
+            msg += f"\n{tank_emoji} - {tank}"
+        for i in range(Operations.sizes[str(op['Size'])]["Tank"] - len(op['Sign-ups']['Tank'])):
+            msg += f"\n{tank_emoji} - "
+        for dps in op['Sign-ups']['Dps']:
+            msg += f"\n{dps_emoji} - {dps}"
+        for i in range(Operations.sizes[str(op['Size'])]["Dps"] - len(op['Sign-ups']['Dps'])):
+            msg += f"\n{dps_emoji} - "
+        for heal in op['Sign-ups']['Healer']:
+            msg += f"\n{heal_emoji} - {heal}"
+        for i in range(Operations.sizes[str(op['Size'])]["Healer"] - len(op['Sign-ups']['Healer'])):
+            msg += f"\n{heal_emoji} - "
+        msg += "\nReserves: "
+        for res in op['Sign-ups']['Reserve']:
+            msg += f"{res}, "
+
+        msg += f"\nTo sign up use -sign {op_id} <role> <alt role>"
+        return msg
+
+    async def edit_pinned_message(self, op: dict, op_number: str, guild_id: int) -> None:
+        """
+        Edits the pinned message for the operation.
+        :param op: The operation details dictionary.
+        :param op_number: The operation id.
+        """
+        dt = await Operations.parse_date(op["Date"], op["Time"])
+        msg = await self.make_operation_message(dt, op, op_number)
+        guild = self.bot.get_guild(guild_id)
+        channel = guild.get_channel(op["Channel_id"])
+        message = get(await channel.history(limit=300).flatten(), id=op["Post_id"])
+
+        await message.edit(content=msg)
 

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -17,7 +17,6 @@ class Admin(Cog):
         return ctx.author.id in admins or ctx.author.id in [168009927015661568]
 
     @command(hidden=True)
-    # @check(is_server_admin)
     async def delete_all(self, ctx: context) -> None:
         """
         Deletes all operations for the given server.
@@ -28,12 +27,16 @@ class Admin(Cog):
         self.ops[str(ctx.guild.id)] = {}
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)
+        await ctx.message.add_reaction('\U0001f44d')
 
     @command(hidden=True)
     async def reset_ids(self, ctx: context) -> None:
         """
         Resets the ids of all operations for the server starting at one.
         """
+        if not await self.is_server_admin(ctx):
+            await ctx.send("You are not authorized to use this command.")
+            return
         ops = self.ops.get(str(ctx.guild.id), ())
         i = 1
         temp = {}
@@ -44,6 +47,7 @@ class Admin(Cog):
         self.ops[str(ctx.guild.id)] = temp
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)
+        await ctx.message.add_reaction('\U0001f44d')
 
     async def make_operation_message(self, dt: datetime, op: dict, op_id: str) -> str:
         """

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -24,6 +24,12 @@ class Admin(Cog):
         if not await self.is_server_admin(ctx):
             await ctx.send("You are not authorized to use this command.")
             return
+        ops = self.ops.get(str(ctx.guild.id), ())
+        for op in ops.values():
+            print(op)
+            channel = ctx.guild.get_channel(op["Channel_id"])
+            message = get(await channel.history(limit=300).flatten(), id=op["Post_id"])
+            await message.unpin()
         self.ops[str(ctx.guild.id)] = {}
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -1,19 +1,31 @@
-from discord.ext.commands import Cog, command, context
+from discord.ext.commands import Cog, command, context, check
+from discord.ext import commands
 from json import dump
 
 
 class Admin(Cog):
-    def __init__(self, bot, ops):
+    def __init__(self, bot, ops: dict, config: dict):
         self.bot = bot
         self.ops = ops
+        self.config = config
+
+    async def is_server_admin(self, ctx: context) -> bool:
+        admins = self.config.get(str(ctx.guild.id), {}).get("Admins", [])
+        return ctx.author.id in admins
 
     @command(hidden=True)
+    @commands.check(is_server_admin)
     async def delete_all(self, ctx: context) -> None:
         """
         Deletes all operations for the given server.
         """
+        if not await self.is_server_admin(ctx):
+            return
         self.ops[str(ctx.guild.id)] = []
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)
+
+
+
 
 

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -22,10 +22,12 @@ class Admin(Cog):
 
     @command(hidden=True)
     async def reset_ids(self, ctx: context) -> None:
+        """
+        Resets the ids of all operations for the server starting at one.
+        """
         ops = self.ops.get(str(ctx.guild.id), ())
         i = 1
         temp = {}
-        print(ops.keys())
         for op in ops.values():
             await self.edit_pinned_message(op, i, ctx.guild.id)
             temp[i] = op

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -7,15 +7,12 @@ class Admin(Cog):
         self.bot = bot
         self.ops = ops
 
-    @command()
+    @command(hidden=True)
     async def delete_all(self, ctx: context) -> None:
         """
         Deletes all operations for the given server.
         """
-        print("Here")
-        print(self.ops)
         self.ops[str(ctx.guild.id)] = []
-        print(self.ops)
         with open('./Ops.json', 'w') as f:
             dump(self.ops, f)
 

--- a/src/Cogs/Admin.py
+++ b/src/Cogs/Admin.py
@@ -16,7 +16,7 @@ class Admin(Cog):
         admins = self.config.get(str(ctx.guild.id), {}).get("Admins", [])
         return ctx.author.id in admins or ctx.author.id in [168009927015661568]
 
-    @command(hidden=True)
+    @command(hidden=True, aliases=["da", "deleteall"])
     async def delete_all(self, ctx: context) -> None:
         """
         Deletes all operations for the given server.
@@ -35,7 +35,7 @@ class Admin(Cog):
             dump(self.ops, f)
         await ctx.message.add_reaction('\U0001f44d')
 
-    @command(hidden=True)
+    @command(hidden=True, aliases=["ri", "resetids"])
     async def reset_ids(self, ctx: context) -> None:
         """
         Resets the ids of all operations for the server starting at one.

--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -524,7 +524,7 @@ class Operations(Cog):
         :return: Booleon True is the user owns the operation or is an Admin.
         """
         server_admins = self.config.get(str(ctx.guild.id), {}).get("Admins", [])
-        return ctx.author.id in ([op["Owner_id"], 168009927015661568] + server_admins)
+        return ctx.author.id in ([op["Owner_id"], 168009927015661568, 165463629171261440] + server_admins)
 
     @staticmethod
     async def parse_date(date: str, time: str) -> datetime:

--- a/src/Cogs/Operations.py
+++ b/src/Cogs/Operations.py
@@ -515,7 +515,6 @@ class Operations(Cog):
         channel = guild.get_channel(op["Channel_id"])
         message = get(await channel.history(limit=300).flatten(), id=op["Post_id"])
 
-        # message = await ctx.fetch_message(op["Post_id"])
         await message.edit(content=msg)
 
     async def is_owner_or_admin(self, ctx: context, op: dict) -> bool:

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -3,6 +3,7 @@ from discord import Game, Intents
 from discord.ext import commands
 from Cogs.Operations import Operations
 from Cogs.Swtor import Swtor
+from Cogs.Admin import Admin
 from json import load
 from Utils.ReactionUtils import *
 from datetime import datetime
@@ -64,5 +65,6 @@ async def github(ctx):
                    "https://github.com/Maskonk/SWTOR_Op_Bot")
 
 client.add_cog(Operations(client, ops, config))
+client.add_cog(Admin(client, ops))
 client.add_cog(Swtor(client, config))
 client.run(token)

--- a/src/OpBot.py
+++ b/src/OpBot.py
@@ -65,6 +65,6 @@ async def github(ctx):
                    "https://github.com/Maskonk/SWTOR_Op_Bot")
 
 client.add_cog(Operations(client, ops, config))
-client.add_cog(Admin(client, ops))
+client.add_cog(Admin(client, ops, config))
 client.add_cog(Swtor(client, config))
 client.run(token)


### PR DESCRIPTION
Adds a new Admin Cog to the bot with two new commands, delete_all which removes all active operations and reset_ids which resets all ids for the server to start at one. Both include a check so that only an Admin can use either command. Also adds Charlie as global bot Admin